### PR TITLE
Use i64 instead of i32 for Version representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +78,36 @@ version = "0.1.3"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,6 +132,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,10 +152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
+"checksum serde 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+"checksum serde_derive 1.0.115 (registry+https://github.com/rust-lang/crates.io-index)" = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+"checksum syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41d17211f887da8e4a70a45b9536f26fc5de166b81e2d5d80de4a17fd22553bd"
+"checksum unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ travis-ci = { repository = "gngeorgiev/semver_rs", branch = "master" }
 lazy_static = "1.1"
 regex = "1"
 unicase = "2.3"
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = []

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,6 +2,9 @@ use crate::error::Error;
 
 use std::marker::PhantomData;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Allows building an [Options](crate::Options) instance.
 /// ## Example
 /// ```
@@ -44,6 +47,7 @@ impl OptionsBuilder {
 /// # Ok::<(), Error>(())
 /// ```
 #[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Options {
     /// Be more forgiving about not-quite-valid semver strings.
     /// Any resulting output will always be 100% strict compliant.

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -12,6 +12,9 @@ use crate::version::Version;
 use std::cmp::Ordering;
 use std::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// ComparatorPair is a simple struct that can hold two comparators
 /// it knows how to format its Comparators
 #[derive(Debug)]
@@ -32,6 +35,7 @@ impl fmt::Display for ComparatorPair {
 /// A `Comparator` is composed of an [Operator](crate::operator::Operator) and a [Version](create::version::Version).
 /// Comparators are the building blocks of [Range](crate::range::Range)s
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Comparator {
     pub operator: Operator,
     pub version: Version,

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,6 +1,10 @@
 use std::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(PartialEq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Operator {
     Gt,
     Lt,

--- a/src/range.rs
+++ b/src/range.rs
@@ -10,6 +10,9 @@ use crate::util::{is_any_version, match_at_index_str};
 use crate::version::Version;
 use std::borrow::Cow;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A `version range` is a set of `comparators` which specify versions that satisfy the `range`.
 /// A comparator is composed of an operator and a version. The set of primitive operators is:
 ///
@@ -34,6 +37,7 @@ use std::borrow::Cow;
 ///
 /// The range `1.2.7 || >=1.2.9 <2.0.0` would match the versions `1.2.7`, `1.2.9`, and `1.4.6`, but not the versions `1.2.8` or `2.0.0`.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Range {
     pub(crate) comparators: Vec<Vec<Comparator>>,
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -14,9 +14,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version {
-    pub major: i32,
-    pub minor: i32,
-    pub patch: i32,
+    pub major: i64,
+    pub minor: i64,
+    pub patch: i64,
     pub prerelease: Option<Vec<String>>,
 
     any: bool,
@@ -82,7 +82,7 @@ impl<'p> Version {
     }
 
     /// Constructs a version from its already parsed parts, e.g. `Version::from_parts(1, 2, 3, None)`.
-    pub fn from_parts(major: i32, minor: i32, patch: i32, prerelease: Option<String>) -> Self {
+    pub fn from_parts(major: i64, minor: i64, patch: i64, prerelease: Option<String>) -> Self {
         let prerelease = match prerelease {
             Some(pre) => {
                 let split: Vec<&str> = pre.split(".").collect();

--- a/src/version.rs
+++ b/src/version.rs
@@ -5,10 +5,14 @@ use crate::util::compare_identifiers;
 
 use std::{cmp::Ordering, fmt, str};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// A `version` is described by the `v2.0.0` specification found at [semver](https://semver.org/).
 ///
 /// A leading `=` or `v` character is stripped off and ignored.
 #[derive(Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version {
     pub major: i32,
     pub minor: i32,


### PR DESCRIPTION
I'm currently trying to parse a large number of `package.json` files from npm (in fact all of them), and I was running into issues where developers put the current date into semvers (i.e. `0.0.2020081300`) which results in the error `number too large to fit in target type`. This PR switches Version number representations from i32 to i64, fixing these issues.